### PR TITLE
kexec-lite native zImage support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,14 +5,17 @@ LIBFDT_LIBADD = -lfdt
 LIBELF_CPPFLAGS =
 LIBELF_LIBADD = -lelf
 
+LIBZ_CPPFLAGS =
+LIBZ_LIBADD = -lz
+
 CFLAGS = -Wall -O2 -ggdb3
 LDFLAGS =
 ASFLAGS =
 
 all: kexec
 
-kexec: CPPFLAGS += $(LIBFDT_CPPFLAGS) $(LIBELF_CPPFLAGS)
-kexec: LIBS += $(LIBFDT_LIBADD) $(LIBELF_LIBADD)
+kexec: CPPFLAGS += $(LIBFDT_CPPFLAGS) $(LIBELF_CPPFLAGS) $(LIBZ_CPPFLAGS)
+kexec: LIBS += $(LIBFDT_LIBADD) $(LIBELF_LIBADD) $(LIBZ_LIBADD)
 
 kexec: kexec.o kexec_trampoline.o kexec_memory_map.o simple_allocator.o
 	$(LINK.o) -o $@ $^ $(LIBS)

--- a/README.md
+++ b/README.md
@@ -6,6 +6,6 @@ A simple kexec for flattened device tree platforms, on PowerPC.
 Dependencies
 ------------
 
-Requires Make, a C toolchain, and the libraries libelf and libfdt.
+Requires Make, a C toolchain, and the libraries libelf, libfdt, and libz.
 
-```sudo apt-get install libelf-dev libfdt-dev```
+```sudo apt-get install libelf-dev libfdt-dev libz-dev```


### PR DESCRIPTION
Based on an old patch provided by @legoater.

Lack of zImage boot support in off-the-shelf openpower boxes has been a recent pain point for us so we'd like to get this in upstream if possible.

We've been using a variant of this patch internally for a long time without any issues :)
