### PR TITLE
kexec: don't ignore kexec_file_load syscall failures

### DIFF
--- a/kexec.c
+++ b/kexec.c
@@ -822,8 +822,10 @@ static void do_file_load(char *kernel, char *initrd, char *cmdline)
 			kernel_fd, initrd_fd, cmdline_len, flags);
 	debug_printf("cmdline=\"%s\"\n", cmdline);
 	ret = syscall_kexec_file_load(kernel_fd, initrd_fd, cmdline_len, cmdline, flags);
-	if (ret)
+	if (ret) {
 		fprintf(stderr, "do_file_load: (%d) %s\n", ret, strerror(errno));
+		exit(1);
+	}
 }
 
 


### PR DESCRIPTION
Currently, a failure from the kexec_file_load syscall will print an
error message, but the kexec process will still report a successful exit
status. This means that callers of kexec cannot fail gracefully on
signature verification errors.

This change adds an early exit (with non-zero exit status) on failure,
in a similar manner to the existing kexec_load error paths.

Signed-off-by: Jeremy Kerr <jk@ozlabs.org>
Fixes: 106891319 (Add support for kexec_file_load)
Cc: Nayna Jain <naynjain@ibm.com>
Cc: Eric Richter <erichte@linux.ibm.com>