### PR TITLE
kexec: improve kexec_file_load error message

### DIFF
--- a/kexec.c
+++ b/kexec.c
@@ -823,7 +823,7 @@ static void do_file_load(char *kernel, char *initrd, char *cmdline)
 	debug_printf("cmdline=\"%s\"\n", cmdline);
 	ret = syscall_kexec_file_load(kernel_fd, initrd_fd, cmdline_len, cmdline, flags);
 	if (ret) {
-		fprintf(stderr, "do_file_load: (%d) %s\n", ret, strerror(errno));
+		fprintf(stderr, "file_load failed: %s\n", strerror(errno));
 		exit(1);
 	}
 }


### PR DESCRIPTION
This change cleans up the error message we get on file_load failure:

 - indicate that it's a failure,
 - no need to mention the internal function name, just that it's a
   file_load issue; and
 - no need to report the syscall return value, it's guaranteed to be -1.

Signed-off-by: Jeremy Kerr <jk@ozlabs.org>